### PR TITLE
Fix canonical metadata fallback for The Memes

### DIFF
--- a/src/alchemy-api/alchemy-api.service.spec.ts
+++ b/src/alchemy-api/alchemy-api.service.spec.ts
@@ -11,10 +11,11 @@ describe(AlchemyApiService.name, () => {
   const getContractMetadata = jest.fn();
   const searchContractMetadata = jest.fn();
   let service: AlchemyApiService;
+  let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     service = new AlchemyApiService(
       {
         nft: {
@@ -64,14 +65,32 @@ describe(AlchemyApiService.name, () => {
       },
     });
 
-    await expect(service.getContractMetadata(MEMES_CONTRACT)).resolves.toEqual({
-      id: MEMES_CONTRACT,
-      address: MEMES_CONTRACT,
+    await expect(
+      service.getContractMetadata(MEMES_CHECKSUM_CONTRACT),
+    ).resolves.toEqual({
+      id: MEMES_CHECKSUM_CONTRACT,
+      address: MEMES_CHECKSUM_CONTRACT,
       name: 'Provider Memes Name',
       tokenType: 'ERC1155',
       imageUrl: 'https://provider.example/memes.png',
       description: 'Provider description',
       openseaVerified: true,
+    });
+  });
+
+  it('returns canonical Memes identity metadata when the provider returns no metadata', async () => {
+    getContractMetadata.mockResolvedValue(null);
+
+    await expect(service.getContractMetadata(MEMES_CONTRACT)).resolves.toEqual({
+      id: MEMES_CONTRACT,
+      address: MEMES_CONTRACT,
+      name: 'The Memes by 6529',
+      tokenType: 'ERC1155',
+      imageUrl: 'https://6529.io/memes-preview.png',
+      description: expect.stringContaining(
+        'focused on the fight for the open metaverse',
+      ),
+      openseaVerified: false,
     });
   });
 
@@ -89,6 +108,33 @@ describe(AlchemyApiService.name, () => {
       ),
       openseaVerified: false,
     });
+  });
+
+  it('only substitutes and logs degraded Memes fields', async () => {
+    getContractMetadata.mockResolvedValue({
+      name: 'Provider Memes Name',
+      tokenType: 'ERC1155',
+      openSea: {
+        description: 'N/A',
+        imageUrl: 'https://provider.example/memes.png',
+        safelistRequestStatus: OpenSeaSafelistRequestStatus.VERIFIED,
+      },
+    });
+
+    await expect(service.getContractMetadata(MEMES_CONTRACT)).resolves.toEqual(
+      expect.objectContaining({
+        name: 'Provider Memes Name',
+        tokenType: 'ERC1155',
+        imageUrl: 'https://provider.example/memes.png',
+        description: expect.stringContaining(
+          'focused on the fight for the open metaverse',
+        ),
+        openseaVerified: true,
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[CONTRACT_METADATA_CANONICAL_FALLBACK] address=${MEMES_CONTRACT} fields=description`,
+    );
   });
 
   it('does not alter degraded metadata for other contracts', async () => {

--- a/src/alchemy-api/alchemy-api.service.spec.ts
+++ b/src/alchemy-api/alchemy-api.service.spec.ts
@@ -1,0 +1,133 @@
+import { HttpService } from '@nestjs/axios';
+import { Logger } from '@nestjs/common';
+import { Alchemy, OpenSeaSafelistRequestStatus } from 'alchemy-sdk';
+import { AlchemyApiService } from './alchemy-api.service';
+import { AlchemyConfig } from './alchemy.config';
+
+const MEMES_CONTRACT = '0x33fd426905f149f8376e227d0c9d3340aad17af1';
+const MEMES_CHECKSUM_CONTRACT = '0x33FD426905F149f8376e227d0C9D3340AaD17aF1';
+
+describe(AlchemyApiService.name, () => {
+  const getContractMetadata = jest.fn();
+  const searchContractMetadata = jest.fn();
+  let service: AlchemyApiService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    service = new AlchemyApiService(
+      {
+        nft: {
+          getContractMetadata,
+          searchContractMetadata,
+        },
+      } as unknown as Alchemy,
+      {} as AlchemyConfig,
+      {} as HttpService,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fills degraded Memes identity metadata with canonical values', async () => {
+    getContractMetadata.mockResolvedValue({
+      name: null,
+      tokenType: 'UNKNOWN',
+      openSea: null,
+    });
+
+    await expect(
+      service.getContractMetadata(MEMES_CHECKSUM_CONTRACT),
+    ).resolves.toEqual({
+      id: MEMES_CONTRACT,
+      address: MEMES_CONTRACT,
+      name: 'The Memes by 6529',
+      tokenType: 'ERC1155',
+      imageUrl: 'https://6529.io/memes-preview.png',
+      description: expect.stringContaining(
+        'focused on the fight for the open metaverse',
+      ),
+      openseaVerified: false,
+    });
+  });
+
+  it('preserves valid provider metadata and verification status', async () => {
+    getContractMetadata.mockResolvedValue({
+      name: 'Provider Memes Name',
+      tokenType: 'ERC1155',
+      openSea: {
+        description: 'Provider description',
+        imageUrl: 'https://provider.example/memes.png',
+        safelistRequestStatus: OpenSeaSafelistRequestStatus.VERIFIED,
+      },
+    });
+
+    await expect(service.getContractMetadata(MEMES_CONTRACT)).resolves.toEqual({
+      id: MEMES_CONTRACT,
+      address: MEMES_CONTRACT,
+      name: 'Provider Memes Name',
+      tokenType: 'ERC1155',
+      imageUrl: 'https://provider.example/memes.png',
+      description: 'Provider description',
+      openseaVerified: true,
+    });
+  });
+
+  it('returns canonical Memes identity metadata when the provider fails', async () => {
+    getContractMetadata.mockRejectedValue(new Error('provider unavailable'));
+
+    await expect(service.getContractMetadata(MEMES_CONTRACT)).resolves.toEqual({
+      id: MEMES_CONTRACT,
+      address: MEMES_CONTRACT,
+      name: 'The Memes by 6529',
+      tokenType: 'ERC1155',
+      imageUrl: 'https://6529.io/memes-preview.png',
+      description: expect.stringContaining(
+        'focused on the fight for the open metaverse',
+      ),
+      openseaVerified: false,
+    });
+  });
+
+  it('does not alter degraded metadata for other contracts', async () => {
+    const address = '0x1111111111111111111111111111111111111111';
+    getContractMetadata.mockResolvedValue({
+      name: null,
+      tokenType: 'UNKNOWN',
+      openSea: null,
+    });
+
+    await expect(service.getContractMetadata(address)).resolves.toEqual({
+      id: address,
+      address,
+      name: 'N/A',
+      tokenType: 'UNKNOWN',
+      imageUrl: null,
+      description: 'N/A',
+      openseaVerified: false,
+    });
+  });
+
+  it('applies the canonical fallback to Memes search results', async () => {
+    searchContractMetadata.mockResolvedValue([
+      {
+        address: MEMES_CHECKSUM_CONTRACT,
+        name: 'N/A',
+        tokenType: 'UNKNOWN',
+        openSea: null,
+      },
+    ]);
+
+    await expect(service.searchContractMetadata('memes')).resolves.toEqual([
+      expect.objectContaining({
+        id: MEMES_CONTRACT,
+        address: MEMES_CONTRACT,
+        name: 'The Memes by 6529',
+        tokenType: 'ERC1155',
+        imageUrl: 'https://6529.io/memes-preview.png',
+      }),
+    ]);
+  });
+});

--- a/src/alchemy-api/alchemy-api.service.ts
+++ b/src/alchemy-api/alchemy-api.service.ts
@@ -13,6 +13,8 @@ const MEMES_CANONICAL_METADATA = {
   description:
     'The Memes Collection is focused on the fight for the open metaverse (decentralization, community, self-sovereignty) and spreading this message to many people, many wallets.\n\nIt is a collection that is meant to be open and accessible. Edition sizes will generally be large and inexpensive, to spread the word and to avoid gas wars.\n\nWe will try to have a good time along the way, make some fun art, do great collabs and just generally have a good time.\n\nFor more information visit https://6529.io/about/the-memes',
 } as const;
+// These exact provider sentinel values are treated as absent only after the
+// response has been gated to the canonical Memes contract address.
 const CONTRACT_METADATA_PLACEHOLDERS = new Set(['n/a', 'unknown']);
 
 export interface ContractMetadataResponse {
@@ -189,14 +191,19 @@ export class AlchemyApiService {
       fallbackFields,
     );
 
-    if (fallbackFields.length) {
+    const usedFallback = fallbackFields.length > 0;
+    if (usedFallback) {
       this.logCanonicalFallback(metadata.address, fallbackFields);
     }
 
     return {
       ...metadata,
-      id: MEMES_CANONICAL_METADATA.id,
-      address: MEMES_CANONICAL_METADATA.address,
+      ...(usedFallback
+        ? {
+            id: MEMES_CANONICAL_METADATA.id,
+            address: MEMES_CANONICAL_METADATA.address,
+          }
+        : {}),
       name,
       tokenType,
       imageUrl,

--- a/src/alchemy-api/alchemy-api.service.ts
+++ b/src/alchemy-api/alchemy-api.service.ts
@@ -1,7 +1,19 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Alchemy, OpenSeaSafelistRequestStatus } from 'alchemy-sdk';
 import { AlchemyConfig } from './alchemy.config';
+
+const MEMES_CONTRACT_ADDRESS = '0x33fd426905f149f8376e227d0c9d3340aad17af1';
+const MEMES_CANONICAL_METADATA = {
+  id: MEMES_CONTRACT_ADDRESS,
+  address: MEMES_CONTRACT_ADDRESS,
+  name: 'The Memes by 6529',
+  tokenType: 'ERC1155',
+  imageUrl: 'https://6529.io/memes-preview.png',
+  description:
+    'The Memes Collection is focused on the fight for the open metaverse (decentralization, community, self-sovereignty) and spreading this message to many people, many wallets.\n\nIt is a collection that is meant to be open and accessible. Edition sizes will generally be large and inexpensive, to spread the word and to avoid gas wars.\n\nWe will try to have a good time along the way, make some fun art, do great collabs and just generally have a good time.\n\nFor more information visit https://6529.io/about/the-memes',
+} as const;
+const CONTRACT_METADATA_PLACEHOLDERS = new Set(['n/a', 'unknown']);
 
 export interface ContractMetadataResponse {
   id: string;
@@ -15,6 +27,7 @@ export interface ContractMetadataResponse {
 
 @Injectable()
 export class AlchemyApiService {
+  private readonly logger = new Logger(AlchemyApiService.name);
   private readonly BASE_URI = 'https://eth-mainnet.g.alchemy.com/';
   private readonly HEADERS = {
     accept: '*/*',
@@ -29,11 +42,42 @@ export class AlchemyApiService {
   async getContractMetadata(
     address: string,
   ): Promise<ContractMetadataResponse | null> {
-    const metadata = await this.alchemy.nft.getContractMetadata(address);
-    if (!metadata) {
-      return null;
+    let metadata;
+    try {
+      metadata = await this.alchemy.nft.getContractMetadata(address);
+    } catch (error) {
+      if (address.toLowerCase() !== MEMES_CONTRACT_ADDRESS) {
+        throw error;
+      }
+      this.logCanonicalFallback(address, [
+        'provider-error',
+        'name',
+        'tokenType',
+        'imageUrl',
+        'description',
+      ]);
+      return {
+        ...MEMES_CANONICAL_METADATA,
+        openseaVerified: false,
+      };
     }
-    return {
+    if (!metadata) {
+      if (address.toLowerCase() !== MEMES_CONTRACT_ADDRESS) {
+        return null;
+      }
+      this.logCanonicalFallback(address, [
+        'provider-empty',
+        'name',
+        'tokenType',
+        'imageUrl',
+        'description',
+      ]);
+      return {
+        ...MEMES_CANONICAL_METADATA,
+        openseaVerified: false,
+      };
+    }
+    return this.applyCanonicalFallback({
       id: address,
       address,
       name: metadata.name ?? metadata.openSea?.collectionName ?? 'N/A',
@@ -43,7 +87,7 @@ export class AlchemyApiService {
       openseaVerified:
         metadata.openSea?.safelistRequestStatus ===
         OpenSeaSafelistRequestStatus.VERIFIED,
-    };
+    });
   }
 
   public async getBlockNumber(): Promise<number> {
@@ -97,16 +141,90 @@ export class AlchemyApiService {
   ): Promise<ContractMetadataResponse[]> {
     const contracts = await this.alchemy.nft.searchContractMetadata(kw);
 
-    return contracts.map((metadata) => ({
-      id: metadata.address,
-      address: metadata.address,
-      name: metadata?.name ?? 'N/A',
-      tokenType: metadata?.tokenType ?? 'N/A',
-      description: metadata?.openSea?.description ?? 'N/A',
-      imageUrl: metadata?.openSea?.imageUrl ?? null, // optional
-      openseaVerified:
-        metadata?.openSea?.safelistRequestStatus ===
-        OpenSeaSafelistRequestStatus.VERIFIED,
-    }));
+    return contracts.map((metadata) =>
+      this.applyCanonicalFallback({
+        id: metadata.address,
+        address: metadata.address,
+        name: metadata?.name ?? 'N/A',
+        tokenType: metadata?.tokenType ?? 'N/A',
+        description: metadata?.openSea?.description ?? 'N/A',
+        imageUrl: metadata?.openSea?.imageUrl ?? null, // optional
+        openseaVerified:
+          metadata?.openSea?.safelistRequestStatus ===
+          OpenSeaSafelistRequestStatus.VERIFIED,
+      }),
+    );
+  }
+
+  private applyCanonicalFallback(
+    metadata: ContractMetadataResponse,
+  ): ContractMetadataResponse {
+    if (metadata.address.toLowerCase() !== MEMES_CONTRACT_ADDRESS) {
+      return metadata;
+    }
+
+    const fallbackFields: string[] = [];
+    const name = this.withCanonicalFallback(
+      metadata.name,
+      MEMES_CANONICAL_METADATA.name,
+      'name',
+      fallbackFields,
+    );
+    const tokenType = this.withCanonicalFallback(
+      metadata.tokenType,
+      MEMES_CANONICAL_METADATA.tokenType,
+      'tokenType',
+      fallbackFields,
+    );
+    const imageUrl = this.withCanonicalFallback(
+      metadata.imageUrl,
+      MEMES_CANONICAL_METADATA.imageUrl,
+      'imageUrl',
+      fallbackFields,
+    );
+    const description = this.withCanonicalFallback(
+      metadata.description,
+      MEMES_CANONICAL_METADATA.description,
+      'description',
+      fallbackFields,
+    );
+
+    if (fallbackFields.length) {
+      this.logCanonicalFallback(metadata.address, fallbackFields);
+    }
+
+    return {
+      ...metadata,
+      id: MEMES_CANONICAL_METADATA.id,
+      address: MEMES_CANONICAL_METADATA.address,
+      name,
+      tokenType,
+      imageUrl,
+      description,
+    };
+  }
+
+  private withCanonicalFallback(
+    value: string | null | undefined,
+    fallback: string,
+    field: string,
+    fallbackFields: string[],
+  ): string {
+    if (
+      !value?.trim() ||
+      CONTRACT_METADATA_PLACEHOLDERS.has(value.trim().toLowerCase())
+    ) {
+      fallbackFields.push(field);
+      return fallback;
+    }
+    return value;
+  }
+
+  private logCanonicalFallback(address: string, fields: string[]): void {
+    this.logger.warn(
+      `[CONTRACT_METADATA_CANONICAL_FALLBACK] address=${address.toLowerCase()} fields=${fields.join(
+        ',',
+      )}`,
+    );
   }
 }


### PR DESCRIPTION
## What
- Add canonical identity metadata fallbacks for The Memes contract (`0x33fd426905f149f8376e227d0c9d3340aad17af1`)
- Apply them to direct metadata, default collection, and search responses
- Preserve valid provider metadata and OpenSea verification status
- Return the canonical identity if Alchemy returns no metadata or errors for this contract only
- Emit a structured warning whenever the fallback is used

## Why
Alchemy began returning `N/A` / `UNKNOWN` and empty OpenSea metadata for The Memes while on-chain token data and snapshot calculations remained healthy. This made the distribution-plan collection picker look broken.

## Impact
Backend/API presentation fix only. No database migration and no change to token ownership, token IDs, balances, or snapshot calculations.

## Checks
- `yarn test --runInBand` (13/13)
- `yarn build`
- `yarn eslint src/alchemy-api/alchemy-api.service.ts src/alchemy-api/alchemy-api.service.spec.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contract metadata reliability when provider responses are incomplete, blank, or unavailable.
  - Added consistent canonical metadata for the Memes contract, including name, token type, image, and description.
  - Added accurate OpenSea verification status handling for Memes metadata.
  - Standardized incomplete metadata for other contracts with neutral placeholder values.
  - Applied the same metadata normalization to contract search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->